### PR TITLE
added back the truthy overload to handle non-nilable types

### DIFF
--- a/elvis.nim
+++ b/elvis.nim
@@ -26,6 +26,9 @@ template truthy*[T](val: seq[T]): bool = (val != @[])
 # true if opt not none
 template truthy*[T](val: Option[T]): bool = isSome(val)
 
+# true if T is not-nilable (This is the catch-all overload)
+template truthy*[T](val: T): bool = not compiles(val.isNil)
+
 # true if truthy and no exception.
 template `?`*[T](val: T): bool = (try: truthy(val) except: false)
 

--- a/tests.nim
+++ b/tests.nim
@@ -28,7 +28,7 @@ suite "truthy":
   test "not empty string": check(?"1")
   test "not zero float": check(?1.1)
   test "not zero int": check(?1)
-  test "not empty seq": check(?[0])
+  test "not empty array": check(?[0])
   test "some option": check(?some(""))
 
 suite "ternary":


### PR DESCRIPTION
We still need this to pass the array check test and to handle anything that is a non-nilable type.