### PR TITLE
Made the elvis operator a macro that checks each step of an expression

### DIFF
--- a/elvis.nim
+++ b/elvis.nim
@@ -110,7 +110,7 @@ proc generateIfExpr(s: seq[NimNode], l, r: NimNode): NimNode =
     let thisExpr =
       genast(expr, argName, r):
         let argName = expr
-        if ?argName:
+        if truthy(argName):
           discard # placerholder rewritten either by next expression or return expression
         else:
           r

--- a/elvis.nim
+++ b/elvis.nim
@@ -117,12 +117,12 @@ proc generateIfExpr(s: seq[NimNode], l, r: NimNode): NimNode =
     if lastExpr.kind == nnkNilLit:
       result = thisExpr
     else:
-      lastExpr[0][1][0][1] = thisExpr
+      lastExpr[1][0][1] = thisExpr
 
     lastExpr = thisExpr
     lastArg = argName
 
-  lastExpr[0][1][0][1] = genAst(l, r, lastArg): # Mimics the logic used prior
+  lastExpr[1][0][1] = genAst(l, r, lastArg): # Mimics the logic used prior
     when l isnot Option and r is Option:
       some(lastArg)
     elif l is Option and r isnot Option:

--- a/tests.nim
+++ b/tests.nim
@@ -103,9 +103,7 @@ suite "elvis number":
 
 
 suite "elvis sequence":
-  #[
   test "empty left": check((seq0 ?: @[1]) == @[1])
-  ]#
   test "good  left": check((@[0] ?: @[1]) == @[0])
 
 suite "elvis except":

--- a/tests.nim
+++ b/tests.nim
@@ -1,7 +1,5 @@
 import elvis
-import unittest
-import tables
-import options
+import std/[unittest, tables, options, sequtils]
 
 template `==`[T](left: Option[T], right: T): bool =
   if isSome(left): left.get() == right else: false
@@ -78,7 +76,7 @@ suite "conditional access":
   var s1 = @["one"]
   var s2 = @["one"]
   test "truthy getter": check(seq1[0].?len == 3) 
-  test "falsey getter": check(seq1[1].?len == 0)
+  #test "falsey getter": check(seq1[1].?len == 0) # Make a custom `{}` or other operator that raises a `CatchableError` instead, defects are not to be caught.
   test "truthy precedence": check(seq1[0].?len == 3) 
   test "nil check": check(nilObj.?data == nil)
   test "falsy on ref": check(nilObj.?data.?val == 0)
@@ -103,8 +101,11 @@ suite "elvis number":
   test "good left": check((1 ?: 2) == 1)
   test "expr left": check(((1 - 1) ?: 1) == 1)
 
+
 suite "elvis sequence":
+  #[
   test "empty left": check((seq0 ?: @[1]) == @[1])
+  ]#
   test "good  left": check((@[0] ?: @[1]) == @[0])
 
 suite "elvis except":
@@ -119,7 +120,7 @@ suite "elvis string":
 suite "elvis except":
   test "none left": check((tab1["two"] ?: 0) == 0)
   test "good left": check((tab1["one"] ?: 0) == 1)
-  
+
 suite "coalesce option and option":
   test "left some":
     let a: Option[string] = some("a")
@@ -243,3 +244,18 @@ suite "short circuit raws":
     proc getB(): string = raise newException(ValueError, "expensive operation")
     expect ValueError:
       discard getA() ?: getB()
+
+suite "Check truthy on chaining":
+  test "filterit":
+    var a: seq[int] = @[]
+    var b = a.filterIt(it > 3)
+
+    check (a.filterIt(it>3)[0] ?: 3) == 3
+
+    type Story = object
+      name: string
+      body: string
+
+    var stories: seq[Story] = @[Story(name:"eh", body: "no")]
+
+    check (stories.filterIt(it.name == "asdf")[0] ?: stories[0]) == stories[0]


### PR DESCRIPTION
This change makes the elvis operator better at handling complex expressions. It also removes the incorrect `try except` usage that caught defects, as they just hide bugs if you use the 'proper' `--panics: on`.

This solves the underlying problem that @ajusa faced.

If replicated for the `?` template it could also resolve #10, #11.